### PR TITLE
開催日で条件抽出（本日以降）

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,7 @@
 <?php
 require('dbconnect.php');
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id GROUP BY events.id');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) GROUP BY events.id');
 $events = $stmt->fetchAll();
 
 function get_day_of_week ($w) {


### PR DESCRIPTION
## 関連イシュー
[ イベント一覧 Issue1 開催日が過去のイベントを表示しない
](https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/1)

## 検証したこと
当日、未来のイベントが表示される
時間が過ぎていても、当日のものであれば表示される

## エビデンス
<img width="1346" alt="スクリーンショット 2022-09-07 11 18 38" src="https://user-images.githubusercontent.com/94168577/188774206-077bfed9-8570-4d1d-94a5-a092e605e841.png">
