### PR TITLE
イベント一覧 Issue2 開催日が近いもの順にソート

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -38,28 +38,28 @@ CREATE TABLE event_user_attendance (
   FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
-INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/09/01 21:00', end_at='2022/09/01 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/09/02 21:00', end_at='2022/09/02 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/09/03 20:00', end_at='2022/09/03 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/09/08 21:00', end_at='2022/09/08 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/09/09 21:00', end_at='2022/09/09 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/09/10 20:00', end_at='2022/09/10 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/09/15 21:00', end_at='2022/09/15 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/09/16 21:00', end_at='2022/09/16 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/09/17 20:00', end_at='2022/09/17 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/09/22 21:00', end_at='2022/09/22 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/09/23 21:00', end_at='2022/09/23 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/09/24 20:00', end_at='2022/09/24 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/22 19:00', end_at='2022/09/22 22:00';
+INSERT INTO events SET name='ハッカソン', start_at='2023/09/03 10:00', end_at='2023/09/03 22:00';
+INSERT INTO events SET name='遊び', start_at='2023/09/06 18:00', end_at='2023/09/06 22:00';
 
 INSERT INTO users (email, name, password, is_admin) VALUES
     ("user0@gmail.com", "user0", "password0", true),
     ("user1@gmail.com", "user1", "password1", false),
     ("user2@gmail.com", "user2", "password2", false),
     ("user3@gmail.com", "user3", "password3", false);
-    
+
 INSERT INTO event_user_attendance SET event_id=1, user_id=1;
 INSERT INTO event_user_attendance SET event_id=1, user_id=1;
 INSERT INTO event_user_attendance SET event_id=1, user_id=1;

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,7 @@
 <?php
 require('dbconnect.php');
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) GROUP BY events.id');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) GROUP BY events.id ORDER BY events.start_at ASC');
 $events = $stmt->fetchAll();
 
 function get_day_of_week ($w) {


### PR DESCRIPTION
## 関連イシュー
[ イベント一覧 Issue2 開催日が近いもの順にソート
](https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/2)
## 検証したこと
ダミーデータを入れて日付順（直近のものから）に並んでるか
## エビデンス
<img width="1348" alt="スクリーンショット 2022-09-07 11 59 30" src="https://user-images.githubusercontent.com/94168577/188780816-bd153117-3e97-4f23-a393-14193c49a809.png">

## 補足
init.sqlはダミーデータの変更のみ
