### PR TITLE
イベント参加管理 Issue1 誰が参加するかDBに保存する

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -30,7 +30,7 @@ CREATE TABLE event_user_attendance (
   id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
   event_id INT NOT NULL,
   user_id INT NOT NULL,
-  attendance_status INT DEFAULT 0,
+  attendance_status INT DEFAULT 0,    /*未回答：0、参加：1、不参加：2*/
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   deleted_at DATETIME,
@@ -60,9 +60,14 @@ INSERT INTO users (email, name, password, is_admin) VALUES
     ("user2@gmail.com", "user2", "password2", false),
     ("user3@gmail.com", "user3", "password3", false);
 
-INSERT INTO event_user_attendance SET event_id=1, user_id=1;
-INSERT INTO event_user_attendance SET event_id=1, user_id=1;
-INSERT INTO event_user_attendance SET event_id=1, user_id=1;
-INSERT INTO event_user_attendance SET event_id=2, user_id=2;
-INSERT INTO event_user_attendance SET event_id=2, user_id=2;
-INSERT INTO event_user_attendance SET event_id=3, user_id=3;
+INSERT INTO event_user_attendance SET event_id=1, user_id=1, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=1, user_id=2, attendance_status=2;
+INSERT INTO event_user_attendance SET event_id=1, user_id=3, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=2, user_id=1, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=2, user_id=2, attendance_status=0;
+INSERT INTO event_user_attendance SET event_id=3, user_id=1, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=4, user_id=1, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=4, user_id=3, attendance_status=2;
+INSERT INTO event_user_attendance SET event_id=5, user_id=1, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=5, user_id=2, attendance_status=1;
+INSERT INTO event_user_attendance SET event_id=6, user_id=2, attendance_status=1;


### PR DESCRIPTION
## 関連するイシュー
[イベント参加管理 Issue1 誰が参加するかDBに保存する](https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/12)
[イベント参加管理 Issue2 誰が参加／不参加の情報をDBに保存する](https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/13)
## 検証したこと
テーブルを見てどのイベントに誰が参加、不参加、未回答かを確認できることを確認
## エビデンス
<img width="1440" alt="スクリーンショット 2022-09-07 15 36 44" src="https://user-images.githubusercontent.com/94168577/188807315-4fb45ad8-ece7-48b8-aec0-d9fea7251dde.png">

## 補足
[テーブル調整、中間テーブル作成](https://github.com/posse-ap/posse1-hackathon-202209-team2D/pull/28)
上記のプルリクにて中間テーブルを作成したことでこのイシューを完了としました。
