### PR TITLE
ログイン機能 Issue3 管理者が対応しなくてもパスワード再設定が出来るようにする

### DIFF
--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -35,7 +35,8 @@ session_start();
       <?php 
       if($_SESSION['login_bool']===0){
         echo '<div class="text-center">emailまたはpasswordが間違っています</div>';
-      }elseif($_SESSION['changed_password'] === 1){
+      }
+      if($_SESSION['changed_password']===1){
         echo '<div class="text-center">passwordを再設定しました</div>';
       }
       ?>

--- a/src/auth/login/resetPassword.php
+++ b/src/auth/login/resetPassword.php
@@ -23,24 +23,18 @@ session_start();
 
   <main class="bg-gray-100 h-screen">
     <div class="w-full mx-auto py-10 px-5">
-      <h2 class="text-md font-bold mb-5">ログイン</h2>
-      <form action="../../controllers/loginPostController.php" method="POST">
+      <h2 class="text-md font-bold mb-5">パスワード再設定フォーム</h2>
+      <form action="../../controllers/forgotPasswordPostController.php" method="POST">
         <input name="email" type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3">
-        <input name="password" type="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3">
-        <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+        <input name="password" type="password" placeholder="新規パスワード" class="w-full p-4 text-sm mb-3">
+        <input name="password_re" type="password" placeholder="新規パスワード再入力" class="w-full p-4 text-sm mb-3">
+        <input type="submit" value="送信" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
-      <div class="text-center text-xs text-gray-400 mt-6">
-        <a href="./resetPassword.php">パスワードを忘れた方はこちら</a>
-      </div>
       <?php 
-      if($_SESSION['login_bool']===0){
-        echo '<div class="text-center">emailまたはpasswordが間違っています</div>';
-      }elseif($_SESSION['changed_password'] === 1){
-        echo '<div class="text-center">passwordを再設定しました</div>';
-      }
+      if($_SESSION['reset_bool']===0){
+        echo '<div>メールアドレスが間違っているか、パスワードが不適切です</div>';}
       ?>
     </div>
   </main>
 </body>
-
 </html>

--- a/src/controllers/forgotPasswordPostController.php
+++ b/src/controllers/forgotPasswordPostController.php
@@ -1,0 +1,30 @@
+<?php
+require '../dbconnect.php';
+session_start();
+
+$_SESSION['changed_password'] = 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $user_stmt = $db->prepare('select * from users where email = :email limit 1;');
+  $user_stmt->bindValue(':email', $_POST['email']);
+  $user_stmt->execute();
+  $user = $user_stmt->fetch();
+  if (empty($user)||empty(trim($_POST['password']))||$_POST['password']!==$_POST['password_re']) {
+    $_SESSION['reset_bool'] = 0;
+    header("Location: ../auth/login/resetPassword.php");
+    exit;
+  } elseif (hash('sha512', $_POST['password']) === $user['password']) {
+    $_SESSION['reset_bool'] = 0;
+    header("Location: ../auth/login/resetPassword.php");
+    exit;
+  } else {
+    $stmt = $db->prepare("UPDATE users SET password = :password WHERE email = :email");
+    $stmt->bindValue(':email', $_POST['email']);
+    $stmt->bindValue(':password', hash('sha512', $_POST['password']));
+    $stmt->execute();
+    $_SESSION['changed_password'] = 1;
+    $_SESSION['login_bool'] = null;
+    header("Location: ../auth/login/index.php");
+    exit;
+  }
+}

--- a/src/controllers/forgotPasswordPostController.php
+++ b/src/controllers/forgotPasswordPostController.php
@@ -23,7 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt->bindValue(':password', hash('sha512', $_POST['password']));
     $stmt->execute();
     $_SESSION['changed_password'] = 1;
-    $_SESSION['login_bool'] = null;
+    unset($_SESSION['login_bool']);
     header("Location: ../auth/login/index.php");
     exit;
   }

--- a/src/controllers/logoutPostController.php
+++ b/src/controllers/logoutPostController.php
@@ -2,5 +2,7 @@
 session_start();
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     unset($_SESSION['login_bool']);
+    unset($_SESSION['reset_bool']);
+    unset($_SESSION['changed_password']);
     header("Location: ../auth/login/index.php");
 }


### PR DESCRIPTION
## 関連するイシュー
[ログイン機能 Issue3 管理者が対応しなくてもパスワード再設定が出来るようにする](https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/9)
## 確認したこと
ユーザー側のみでパスワードの再設定が可能
正しいエラーメッセージが表示される
## エビデンス
<img width="307" alt="スクリーンショット 2022-09-07 22 54 46" src="https://user-images.githubusercontent.com/94168577/188896236-4c7dede5-508e-4de9-b2e9-7ed5236c429b.png">
<img width="333" alt="スクリーンショット 2022-09-07 22 48 17" src="https://user-images.githubusercontent.com/94168577/188896349-440b2983-77e6-46cc-9a0b-11a5a498e368.png">

## 補足
一般ユーザーも通常ログイン後、リンクを知っていれば管理者画面に行けてしまったので、下のPRで修正しました
[管理画面 Issue2 画面からイベント内容も登録出来るようにする](https://github.com/posse-ap/posse1-hackathon-202209-team2D/pull/57)
