### PR TITLE
通知機能 Issue2

### DIFF
--- a/src/mail_1day_ago_all.php
+++ b/src/mail_1day_ago_all.php
@@ -20,12 +20,17 @@ foreach ($events as $event) {
     $notification_date = $designated_time->format('Y-m-d'); //通知日
 
     // 通知日と今日が同じが同じならメール
+    mb_language("ja");
+    mb_internal_encoding("utf-8");
     if ($notification_date == $today) {
         foreach ($users as $user) {
             $to = $user['email'];
             $subject = "一日前通知！";
             $body = '【リマインド】イベント名「' . $event['name'] . '」の一日前です。内容は「' .$event['detail']  .'」です。開催日時は' .$event['start_at']  .'です。回答をお願いします。このメールは入力状況に関わらず全員に通知しています。';
             $headers = "From: system@posse-ap.com";
+            $headers .= "MIME-Version: 1.0\n";
+            $headers .= "Content-Transfer-Encoding: BASE64\n";
+            $headers .= "Content-Type: text/plain; charset=UTF-8\n";
             if (mb_send_mail($to, $subject, $body, $headers)) {
                 print_r('<pre>');
                 echo $event['name'];

--- a/src/mail_1day_ago_all.php
+++ b/src/mail_1day_ago_all.php
@@ -1,0 +1,45 @@
+<?php
+require('dbconnect.php');
+
+$stmt = $db->query('SELECT * FROM events');
+$events = $stmt->fetchAll();
+
+$stmt = $db->query('SELECT * FROM users');
+$users = $stmt->fetchAll();
+
+foreach ($events as $event) {
+
+    $now_time = new DateTime(); //現在日時
+
+    $designated_time = new DateTime($event['start_at']); //指定日時
+    $designated_date = $designated_time->format('Y-m-d'); //指定日
+
+    $notification_date = $designated_time->modify('-1 day'); //通知日時は一日前
+
+    $today = $now_time->format('Y-m-d'); //現在日
+    $notification_date = $designated_time->format('Y-m-d'); //通知日
+
+    // 通知日と今日が同じが同じならメール
+    if ($notification_date == $today) {
+        foreach ($users as $user) {
+            $to = $user['email'];
+            $subject = "一日前通知！";
+            $body = '【リマインド】イベント名「' . $event['name'] . '」の一日前です。内容は「' .$event['detail']  .'」です。開催日時は' .$event['start_at']  .'です。回答をお願いします。このメールは入力状況に関わらず全員に通知しています。';
+            $headers = "From: system@posse-ap.com";
+            if (mb_send_mail($to, $subject, $body, $headers)) {
+                print_r('<pre>');
+                echo $event['name'];
+                echo 'は';
+                echo $designated_date;
+                echo 'に開催予定で、一日前であり、送信した内容は、「';
+                echo $body;
+                echo '」であり、';
+                echo $to;
+                echo 'に正常に送信されました。';
+                print_r('</pre>');
+            } else {
+                echo "メール送信失敗です";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 関連issue
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/18

## 検証したこと
バッチを実行すると処理日がイベントの前日の場合メールを送付する
メールの宛先はユーザレコードの人全て
メールにはイベント名、内容、開催日時を記載する

備考
今日は9/8であり、9/9の内容が扱われる

## エビデンス
使用したテーブル

ユーザーテーブル
<img width="1054" alt="スクリーンショット 2022-09-08 9 30 53" src="https://user-images.githubusercontent.com/86601605/189007793-2043960c-04fe-4a25-a6e3-d8a9c023edef.png">

イベントテーブル
<img width="1071" alt="スクリーンショット 2022-09-08 9 42 57" src="https://user-images.githubusercontent.com/86601605/189008898-43c969f8-558d-4f04-a5b9-8af4dc7dcee8.png">

パッチの結果
<img width="1440" alt="スクリーンショット 2022-09-08 9 41 43" src="https://user-images.githubusercontent.com/86601605/189008784-0b6dc6d9-2c03-4200-b455-71a5477f38c3.png">


メールホグの画面
<img width="1440" alt="スクリーンショット 2022-09-08 9 39 51" src="https://user-images.githubusercontent.com/86601605/189008610-842ccab7-a105-450e-a516-fb25367b5219.png">

メールの内容
<img width="1078" alt="スクリーンショット 2022-09-08 10 06 21" src="https://user-images.githubusercontent.com/86601605/189011141-6a393d83-ae1c-4b41-b99b-ce6190538e56.png">


