### PR TITLE
通知機能 Issue3

### DIFF
--- a/src/mail_1day_ago_participant.php
+++ b/src/mail_1day_ago_participant.php
@@ -7,8 +7,11 @@ $events = $stmt->fetchAll();
 foreach ($events as $event) {
     $to = $event['email'];
     $subject = "未回答者様へ";
-    $body = '【リマインド】イベント名「' . $event['name'] . '」の一日前です。内容は「' .$event['detail']  .'」です。開催日時は' .$event['start_at']  .'です。回答をお願いします。このメールは参加者のみに通知しています。';;
+    $body = '【リマインド】イベント名「' . $event['name'] . '」の一日前です。内容は「' . $event['detail']  . '」です。開催日時は' . $event['start_at']  . 'です。回答をお願いします。このメールは参加者のみに通知しています。';;
     $headers = "From: system@posse-ap.com";
+    $headers .= "MIME-Version: 1.0\n";
+    $headers .= "Content-Transfer-Encoding: BASE64\n";
+    $headers .= "Content-Type: text/plain; charset=UTF-8\n";
 
     $now_time = new DateTime(); //現在日時
     $designated_time = new DateTime($event['start_at']); //指定日時

--- a/src/mail_1day_ago_participant.php
+++ b/src/mail_1day_ago_participant.php
@@ -1,0 +1,39 @@
+<?php
+require('dbconnect.php');
+
+$stmt = $db->query('SELECT * FROM event_user_attendance eua  INNER JOIN users u ON  eua.user_id = u.id INNER JOIN events e ON  eua.event_id = e.id WHERE attendance_status = 1');
+$events = $stmt->fetchAll();
+
+foreach ($events as $event) {
+    $to = $event['email'];
+    $subject = "未回答者様へ";
+    $body = '【リマインド】イベント名「' . $event['name'] . '」の一日前です。内容は「' .$event['detail']  .'」です。開催日時は' .$event['start_at']  .'です。回答をお願いします。このメールは参加者のみに通知しています。';;
+    $headers = "From: system@posse-ap.com";
+
+    $now_time = new DateTime(); //現在日時
+    $designated_time = new DateTime($event['start_at']); //指定日時
+    $designated_date = $designated_time->format('Y-m-d');
+
+    $notification_date = $designated_time->modify('-1 day'); //通知日時
+
+    $today = $now_time->format('Y-m-d'); //現在日
+    $notification_date = $designated_time->format('Y-m-d'); //通知日
+
+    // 通知日と今日が同じが同じならメール
+    if ($notification_date == $today) {
+        if (mb_send_mail($to, $subject, $body, $headers)) {
+            print_r('<pre>');
+            echo $event['name'];
+            echo 'は';
+            echo $designated_date;
+            echo 'に開催されるため今日は一日前であり、「';
+            echo $body;
+            echo '」は参加者である';
+            echo $to;
+            echo 'に送信されました';
+            print_r('</pre>');
+        } else {
+            echo "メール送信失敗です";
+        }
+    }
+}

--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -1,8 +1,0 @@
-<?php
-
-$to = "hackathon-teamX@posse-ap.com";
-$subject = "PHPからメール送信サンプル";
-$body = "本文";
-$headers = "From: system@posse-ap.com";
-
-mb_send_mail($to, $subject, $body, $headers);


### PR DESCRIPTION
## 関連issue
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/19

## 検証したこと
バッチを実行すると処理日がイベントの前日の場合メールを送付する
メールの宛先は参加としている人のみ
メールにはイベント名、内容、開催日時を記載する

備考
今日は9/8であり、9/9の内容が扱われる

## エビデンス
使用したテーブル

ユーザーテーブル
<img width="1054" alt="スクリーンショット 2022-09-08 9 30 53" src="https://user-images.githubusercontent.com/86601605/189007793-2043960c-04fe-4a25-a6e3-d8a9c023edef.png">

イベントテーブル
<img width="1072" alt="スクリーンショット 2022-09-08 9 30 30" src="https://user-images.githubusercontent.com/86601605/189007773-49b6ab39-1a60-4dd4-bf66-9732e3a828ca.png">

中間テーブル
<img width="903" alt="スクリーンショット 2022-09-08 9 32 38" src="https://user-images.githubusercontent.com/86601605/189007901-d533d25c-1cb8-4c8e-a36a-7a71840055d1.png">

パッチの結果
<img width="1440" alt="スクリーンショット 2022-09-08 10 00 25" src="https://user-images.githubusercontent.com/86601605/189010650-961568b6-e420-4178-a66c-aceeecdec121.png">


メールホグの画面
<img width="1149" alt="スクリーンショット 2022-09-08 10 02 23" src="https://user-images.githubusercontent.com/86601605/189010804-8266fa42-11c1-46d8-b6cc-7e028073ea3f.png">


メールの内容
<img width="1131" alt="スクリーンショット 2022-09-08 10 02 49" src="https://user-images.githubusercontent.com/86601605/189010866-34d5d550-cb79-4667-9169-7d6ddaa4d6cc.png">



