### PR TITLE
イベント参加管理 Issue3 参加状態により参加／不参加ボタンを活性／非活性にする 【前編】

### DIFF
--- a/src/controllers/eventsGetController.php
+++ b/src/controllers/eventsGetController.php
@@ -13,7 +13,7 @@ function group_by($key, array $ary): array
 
     return $result;
 }
-//イベント一覧を取得
+//イベント一覧を取得,idをキーとすることでeager loadの再現をしやすくしている
 $events_stmt = $db->query('select id,name,start_at,end_at,detail from events order by start_at asc;');
 $events = $events_stmt->fetchAll(PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE);
 //出席一覧を取得
@@ -39,9 +39,9 @@ $events_filtered_by_login_user_attendance_status = [];
 if (!isset($_GET['attendance_status'])) {
     $events_filtered_by_login_user_attendance_status = $events;
 } else {
-    foreach ($events as $event) {
+    foreach ($events as $event_id=>$event) {
         if ($_GET['attendance_status'] === $event['login_user_attendance_status']) {
-            array_push($events_filtered_by_login_user_attendance_status, $event);
+            $events_filtered_by_login_user_attendance_status=$events_filtered_by_login_user_attendance_status+array($event_id=>$event);
         }
     }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -68,14 +68,14 @@ function get_day_of_week($w)
             <a href="" class="text-gray-400">カレンダー</a>
           </div>
         </div>
-
-        <?php foreach ($events_filtered_by_login_user_attendance_status as $event) : ?>
+        
+        <?php foreach ($events_filtered_by_login_user_attendance_status as $event_id=>$event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event_<?php echo $event_id; ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
@@ -120,7 +120,8 @@ function get_day_of_week($w)
           </svg>
         </div>
 
-        <div id="modalInner"></div>
+        <div id="modalInner">
+        </div>
 
       </div>
     </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,17 +1,17 @@
 'use strict'
-const openModalClassList = document.querySelectorAll('.modal-open');
-const closeModalClassList = document.querySelectorAll('.modal-close');
-const overlay = document.querySelector('.modal-overlay');
-const body = document.querySelector('body');
-const modal = document.querySelector('.modal');
-const modalInnerHTML = document.getElementById('modalInner');
+const openModalClassList = document.querySelectorAll('.modal-open')
+const closeModalClassList = document.querySelectorAll('.modal-close')
+const overlay = document.querySelector('.modal-overlay')
+const body = document.querySelector('body')
+const modal = document.querySelector('.modal')
+const modalInnerHTML = document.getElementById('modalInner')
 
 for (let i = 0; i < openModalClassList.length; i++) {
   openModalClassList[i].addEventListener('click', (e) => {
-    e.preventDefault();
-    let eventId = parseInt(e.currentTarget.id.replace('event_', ''));
-    openModal(eventId);
-  }, false);
+    e.preventDefault()
+    let eventId = parseInt(e.currentTarget.id.replace('event_', ''))
+    openModal(eventId)
+  }, false)
 }
 
 for (var i = 0; i < closeModalClassList.length; i++) {
@@ -23,9 +23,9 @@ overlay.addEventListener('click', closeModal)
 
 async function openModal(eventId) {
   try {
-    const url = '/api/getModalInfo.php?event_id=' + eventId;
-    const res = await fetch(url);
-    const event = await res.json();
+    const url = '/api/getModalInfo.php?event_id=' + eventId
+    const res = await fetch(url)
+    const event = await res.json()
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -51,26 +51,26 @@ async function openModal(eventId) {
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
           </div>
-        `;
+        `
         break;
       case '1':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
-        `;
+        `
         break;
       case '2':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-green-400">参加</p>
           </div>
-        `;
+        `
         break;
     }
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
   } catch (error) {
-    console.log(error);
+    console.log(error)
   }
   toggleModal()
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -53,14 +53,14 @@ async function openModal(eventId) {
           </div>
         `;
         break;
-      case '2':
+      case '1':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
         `;
         break;
-      case '1':
+      case '2':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-green-400">参加</p>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,17 +1,17 @@
 'use strict'
-const openModalClassList = document.querySelectorAll('.modal-open')
-const closeModalClassList = document.querySelectorAll('.modal-close')
-const overlay = document.querySelector('.modal-overlay')
-const body = document.querySelector('body')
-const modal = document.querySelector('.modal')
-const modalInnerHTML = document.getElementById('modalInner')
+const openModalClassList = document.querySelectorAll('.modal-open');
+const closeModalClassList = document.querySelectorAll('.modal-close');
+const overlay = document.querySelector('.modal-overlay');
+const body = document.querySelector('body');
+const modal = document.querySelector('.modal');
+const modalInnerHTML = document.getElementById('modalInner');
 
 for (let i = 0; i < openModalClassList.length; i++) {
   openModalClassList[i].addEventListener('click', (e) => {
-    e.preventDefault()
-    let eventId = parseInt(e.currentTarget.id.replace('event-', ''))
-    openModal(eventId)
-  }, false)
+    e.preventDefault();
+    let eventId = parseInt(e.currentTarget.id.replace('event_', ''));
+    openModal(eventId);
+  }, false);
 }
 
 for (var i = 0; i < closeModalClassList.length; i++) {
@@ -23,9 +23,9 @@ overlay.addEventListener('click', closeModal)
 
 async function openModal(eventId) {
   try {
-    const url = '/api/getModalInfo.php?eventId=' + eventId
-    const res = await fetch(url)
-    const event = await res.json()
+    const url = '/api/getModalInfo.php?event_id=' + eventId;
+    const res = await fetch(url);
+    const event = await res.json();
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -36,13 +36,12 @@ async function openModal(eventId) {
       <p class="text-md">
         ${event.message}
       </p>
-
       <hr class="my-4">
 
       <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
-    `
+    `;
     switch (event.status) {
-      case 0:
+      case '0':
         modalHTML += `
           <div class="text-center mt-6">
             <p class="text-lg font-bold text-yellow-400">未回答</p>
@@ -52,26 +51,26 @@ async function openModal(eventId) {
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
           </div>
-        `
+        `;
         break;
-      case 1:
+      case '2':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
-        `
+        `;
         break;
-      case 2:
+      case '1':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-green-400">参加</p>
           </div>
-        `
+        `;
         break;
     }
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
   } catch (error) {
-    console.log(error)
+    console.log(error);
   }
   toggleModal()
 }


### PR DESCRIPTION
## 関連イシュー
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/14
## 検証したこと
参加予定のイベント、不参加予定のイベント、未回答のイベントのモーダルを開いたときの挙動を比較
## エビデンス
ラーメン次郎というイベントは参加予定
![image](https://user-images.githubusercontent.com/86890087/189012846-f565771f-d3be-424b-8ca3-a9cba4d9732b.png)
モーダル開くと不参加ボタンが活性化されている
![image](https://user-images.githubusercontent.com/86890087/189012867-d4bca86a-c423-4ef0-a90b-05bb35e9e4fc.png)
カタールというイベントは不参加予定
![image](https://user-images.githubusercontent.com/86890087/189012971-38e764dc-0b94-4b57-b504-2b1efd726fca.png)
モーダル開くと参加ボタンが活性化されている
![image](https://user-images.githubusercontent.com/86890087/189013018-c2d7c60f-ba7c-422b-94d5-1dbb782458a7.png)
試合というイベントは未回答
![image](https://user-images.githubusercontent.com/86890087/189013159-0bc1a7d1-bf37-433e-8fae-33d2c9cb06fd.png)
モーダル開くと参加ボタンと不参加ボタン両方が活性化されている
![image](https://user-images.githubusercontent.com/86890087/189013198-8c99a2cf-72e4-4083-93d6-ab1416685b52.png)

## 補足
活性、非活性の意味を間違えて捉えていたため別のプルリクで修正しました
https://github.com/posse-ap/posse1-hackathon-202209-team2D/pull/64

