### PR TITLE
イベント参加管理 Issue4 トップページに自身の回答状況を表示する

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -87,7 +87,7 @@ function get_day_of_week($w)
               <div>
                 <?php if ($event['login_user_attendance_status'] == 0) : ?>
                   <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $start_date)); ?></p>
                 <?php elseif ($event['login_user_attendance_status'] == 2) : ?>
                   <p class="text-sm font-bold text-gray-300">不参加</p>
                 <?php elseif ($event['login_user_attendance_status'] == 1) : ?>


### PR DESCRIPTION
## 関連するイシュー
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/15
## 関連するPR
https://github.com/posse-ap/posse1-hackathon-202209-team2D/pull/42
こちらのPRで回答状況を表示する機能自体は完成しています
## 検証したこと
user_id4のユーザーとしてログインして表示内容を確認した
user3@gmail.com

## エビデンス
user_id4のユーザーとして全てを表示
![image](https://user-images.githubusercontent.com/86890087/189025740-6644a7e6-fab7-4c64-9fed-d07e70d294c9.png)
user_id4のユーザーとして参加予定を表示
![image](https://user-images.githubusercontent.com/86890087/189025782-973b63f4-9e0e-41e6-9df7-4a431ad1131e.png)
user_id4のユーザーとして不参加予定を表示
![image](https://user-images.githubusercontent.com/86890087/189025809-aa3c51bc-56f0-4b51-9af9-f9a7553992fe.png)
user_id4のユーザーとして未回答予定を表示
![image](https://user-images.githubusercontent.com/86890087/189025974-e218d8a0-d92d-44a2-8652-c6ff3b50b75d.png)
user_id4のイベント出欠データ
![image](https://user-images.githubusercontent.com/86890087/189026680-403d7546-3c26-4016-a2b4-50d9438fb3b5.png)
イベント一覧データ
![image](https://user-images.githubusercontent.com/86890087/189026757-9727ae5d-b6b3-475b-b065-29d262721e15.png)


