### PR TITLE
管理画面 Issue1 画面からイベントを登録出来るようにする項目はイベント名、開催日時、イベント内容は空

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -10,7 +10,7 @@ CREATE TABLE
     events (
         id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
         name VARCHAR(10) NOT NULL,
-        detail VARCHAR(128) NOT NULL,
+        detail VARCHAR(128) DEFAULT NULL,
         start_at DATETIME,
         end_at DATETIME,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -33,15 +33,21 @@ function get_day_of_week($w)
       <form action="../controllers/logoutPostController.php" method="POST">
         <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
       </form>
-      <a href="./userRegister.php" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">ユーザー登録</a>
-      <!-- <form action="./userRegister.php" method="post">
-        <input value="ユーザー登録" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
-      </form> -->
     </div>
   </header>
 
   <main class="bg-gray-100">
     <div class="w-full mx-auto p-5">
+      <div id="filter" class="mb-8">
+        <h2 class="text-sm font-bold mb-3">メニュー</h2>
+        <div class="flex">
+          <a href="" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベントリスト</a>
+          <a href="./userRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー登録</a>
+          <a href="./eventRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベント追加</a>
+          <a href="/" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー画面へ</a>
+
+        </div>
+      </div>
       <div id="events-list">
         <div class="flex justify-between items-center mb-3">
           <h2 class="text-sm font-bold">一覧</h2>
@@ -50,7 +56,7 @@ function get_day_of_week($w)
             <a href="" class="text-gray-400">カレンダー</a>
           </div>
         </div>
-        
+
         <?php foreach ($events as $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);

--- a/src/admin/eventRegister.php
+++ b/src/admin/eventRegister.php
@@ -42,13 +42,14 @@ function get_day_of_week($w)
         <h2 class="text-sm font-bold mb-3">メニュー</h2>
         <div class="flex">
           <a href="./admin.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベントリスト</a>
-          <a href="" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー登録</a>
+          <a href="./userRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー登録</a>
           <a href="./eventRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベント追加</a>
           <a href="/" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー画面へ</a>
+
         </div>
       </div>
     <div class="w-full mx-auto py-10 px-5">
-      <h2 class="text-md font-bold mb-5">ユーザー登録</h2>
+      <h2 class="text-md font-bold mb-5">イベント登録</h2>
       <form action="../../controllers/registerController.php" method="POST">
         <p>名前</p>
         <input name="name" type="name" placeholder="名前" class="w-full p-4 text-sm mb-3">

--- a/src/admin/eventRegister.php
+++ b/src/admin/eventRegister.php
@@ -50,19 +50,15 @@ function get_day_of_week($w)
       </div>
     <div class="w-full mx-auto py-10 px-5">
       <h2 class="text-md font-bold mb-5">イベント登録</h2>
-      <form action="../../controllers/registerController.php" method="POST">
-        <p>名前</p>
-        <input name="name" type="name" placeholder="名前" class="w-full p-4 text-sm mb-3">
-        <p>メールアドレス</p>
-        <input name="email" type="email" placeholder="メールアドレス" class="w-full p-4 text-sm mb-3">
-        <p>パスワード</p>
-        <input name="password" type="password" placeholder="パスワード" class="w-full p-4 text-sm mb-3">
-        <p>管理者権限</p>
-        <label class="flex items-center"><input name="is_admin" type="checkbox" value="1" class="h-full ml-3 mr-3 p-4 text-sm">管理者権限を付与</label>
-        <p>github ID</p>
-        <input name="githubID" type="email" placeholder="github ID" class="w-full p-4 text-sm mb-3">
-        <p>slack ID</p>
-        <input name="slackID" type="email" placeholder="slack ID" class="w-full p-4 text-sm mb-3">
+      <form action="../../controllers/eventRegisterController.php" method="POST">
+        <p>イベント名</p>
+        <input name="event_name" type="name" class="w-full p-4 text-sm mb-3">
+        <p>イベント詳細</p>
+        <textarea name="detail" rows="4" class="w-full"></textarea>
+        <p>開催日時</p>
+        <input name="start_at" type="datetime-local" class="w-full p-4 text-sm mb-3">
+        <p>終了日時</p>
+        <input name="end_at" type="datetime-local" class="w-full p-4 text-sm mb-3">
         <input type="submit" value="登録" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
     </div>

--- a/src/controllers/eventRegisterController.php
+++ b/src/controllers/eventRegisterController.php
@@ -1,0 +1,21 @@
+<?php
+require '../dbconnect.php';
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
+    $name = $_POST['event_name'];
+    $detail = $_POST['detail'];
+    $start_at = $_POST['start_at'];
+    $end_at = $_POST['end_at'];
+
+    $regi_stmt = $db->prepare("INSERT INTO events (name, detail, start_at, end_at) VALUES (:name, :detail, :start_at, :end_at);");
+    $regi_stmt->bindValue(':name',$name);
+    $regi_stmt->bindValue(':detail',$detail);
+    $regi_stmt->bindValue(':start_at',$start_at);
+    $regi_stmt->bindValue(':end_at',$end_at);
+    $regi_stmt->execute();
+
+    header("Location:  /../admin/admin.php");
+    exit;
+}

--- a/src/index.php
+++ b/src/index.php
@@ -2,6 +2,7 @@
 require('dbconnect.php');
 require './controllers/loginGetController.php';
 require './controllers/eventsGetController.php';
+session_start();
 
 function get_day_of_week($w)
 {
@@ -27,9 +28,17 @@ function get_day_of_week($w)
       <div class="h-full">
         <img src="img/header-logo.png" alt="" class="h-full">
       </div>
-      <form action="./controllers/logoutPostController.php" method="POST">
-        <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
-      </form>
+      <div class="flex">
+        <form action="./controllers/logoutPostController.php" method="POST">
+          <input value="ログアウト" type="submit" class="mr-2 text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
+        </form>
+        <?php
+        // echo $_SESSION['login_user']['is_admin'];
+        if ($_SESSION['login_user']['is_admin']) {
+          echo '<a href="./admin/admin.php" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">管理者画面へ</a>';
+        }
+        ?>
+      </div>
     </div>
   </header>
 
@@ -55,7 +64,7 @@ function get_day_of_week($w)
                                                                                                                                                     } ?>">不参加</a>
           <a href="index.php?attendance_status=0" class="buttons_to_change_attendance_filter px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md <?php if ($_GET['attendance_status'] == 0 && isset($_GET['attendance_status'])) {
                                                                                                                                                       echo 'bg-blue-600 text-white';
-                                                                                                                                                    } elseif($_GET['attendance_status']!=0 && isset($_GET['attendance_status'])) {
+                                                                                                                                                    } elseif ($_GET['attendance_status'] != 0 && isset($_GET['attendance_status'])) {
                                                                                                                                                       echo 'bg-white';
                                                                                                                                                     } ?>">未回答</a>
         </div>
@@ -68,8 +77,8 @@ function get_day_of_week($w)
             <a href="" class="text-gray-400">カレンダー</a>
           </div>
         </div>
-        
-        <?php foreach ($events_filtered_by_login_user_attendance_status as $event_id=>$event) : ?>
+
+        <?php foreach ($events_filtered_by_login_user_attendance_status as $event_id => $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);


### PR DESCRIPTION
## 関連するイシュー
[管理画面 Issue1 画面からイベントを登録出来るようにする項目はイベント名、開催日時、イベント内容は空](https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/21)
## 確認したこと
管理者権限の有無で管理者画面へのアクセス可否を確認
管理者画面からイベントを追加できることを確認
## エビデンス
user0：管理者
user1：一般

<img width="1440" alt="スクリーンショット 2022-09-08 12 42 16" src="https://user-images.githubusercontent.com/94168577/189029379-937a36cc-d471-4494-af63-648c70b250b5.png">

<img width="1440" alt="スクリーンショット 2022-09-08 12 42 24" src="https://user-images.githubusercontent.com/94168577/189029388-b65938c3-dc90-4ffd-9e27-e15320647400.png">

<img width="1440" alt="スクリーンショット 2022-09-08 12 42 50" src="https://user-images.githubusercontent.com/94168577/189029398-75b4635c-1254-41e4-ab7a-feb4ae576237.png">
<img width="1440" alt="スクリーンショット 2022-09-08 12 42 56" src="https://user-images.githubusercontent.com/94168577/189029411-8fab4841-61b9-45f9-acdc-b553f694e7c2.png">
<img width="1440" alt="スクリーンショット 2022-09-08 11 24 22" src="https://user-images.githubusercontent.com/94168577/189029444-e10266a5-395d-4465-93c2-1155c5462e66.png">
<img width="1440" alt="スクリーンショット 2022-09-08 11 30 25" src="https://user-images.githubusercontent.com/94168577/189029449-c3162d4e-f52b-4b96-9fc3-c1f484a7846a.png">
