### PR TITLE
管理画面 Issue2 画面からイベント内容も登録出来るようにする

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -9,7 +9,7 @@ DROP TABLE IF EXISTS events;
 CREATE TABLE
     events (
         id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
-        name VARCHAR(10) NOT NULL,
+        name VARCHAR(20) NOT NULL,
         detail VARCHAR(128) DEFAULT NULL,
         start_at DATETIME,
         end_at DATETIME,

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -30,10 +30,12 @@ function get_day_of_week($w)
       <div class="h-full">
         <img src="../img/header-logo.png" alt="" class="h-full">
       </div>
-      <form action="../controllers/logoutPostController.php" method="POST">
-        <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
-      </form>
-      <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+      <div class="flex">
+        <form action="../controllers/logoutPostController.php" method="POST">
+          <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
+        </form>
+        <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+      </div>
     </div>
   </header>
 

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -1,6 +1,6 @@
 <?php
 require_once(dirname(__FILE__) . "/../dbconnect.php");
-require_once(dirname(__FILE__) . "/../controllers/loginGetController.php");
+require_once(dirname(__FILE__) . "/../controllers/adminLoginGetController.php");
 session_start();
 
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) GROUP BY events.id ORDER BY events.start_at ASC');

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -64,7 +64,7 @@ function get_day_of_week($w)
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+          <div class="admin-modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event_<?php echo $event['id']; ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
@@ -73,16 +73,6 @@ function get_day_of_week($w)
               </p>
             </div>
             <div class="flex flex-col justify-between text-right">
-              <div>
-                <?php if ($event['id'] % 3 === 1) : ?>
-                  <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
-                <?php elseif ($event['id'] % 3 === 2) : ?>
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                <?php else : ?>
-                  <p class="text-sm font-bold text-green-400">参加</p>
-                <?php endif; ?>
-              </div>
               <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加 ></p>
             </div>
           </div>

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -33,6 +33,7 @@ function get_day_of_week($w)
       <form action="../controllers/logoutPostController.php" method="POST">
         <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
       </form>
+      <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
     </div>
   </header>
 
@@ -41,11 +42,9 @@ function get_day_of_week($w)
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">メニュー</h2>
         <div class="flex">
-          <a href="" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベントリスト</a>
+          <a href="" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">イベントリスト</a>
           <a href="./userRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー登録</a>
           <a href="./eventRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベント追加</a>
-          <a href="/" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー画面へ</a>
-
         </div>
       </div>
       <div id="events-list">

--- a/src/admin/eventRegister.php
+++ b/src/admin/eventRegister.php
@@ -1,6 +1,6 @@
 <?php
 require_once(dirname(__FILE__) . "/../dbconnect.php");
-require_once(dirname(__FILE__) . "/../controllers/loginGetController.php");
+require_once(dirname(__FILE__) . "/../controllers/adminLoginGetController.php");
 session_start();
 
 

--- a/src/admin/eventRegister.php
+++ b/src/admin/eventRegister.php
@@ -34,6 +34,7 @@ function get_day_of_week($w)
       <form action="../controllers/logoutPostController.php" method="POST">
         <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
       </form>
+      <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
     </div>
   </header>
   <main class="bg-gray-100">
@@ -43,9 +44,7 @@ function get_day_of_week($w)
         <div class="flex">
           <a href="./admin.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベントリスト</a>
           <a href="./userRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー登録</a>
-          <a href="./eventRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベント追加</a>
-          <a href="/" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー画面へ</a>
-
+          <a href="./eventRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">イベント追加</a>
         </div>
       </div>
     <div class="w-full mx-auto py-10 px-5">

--- a/src/admin/eventRegister.php
+++ b/src/admin/eventRegister.php
@@ -31,10 +31,12 @@ function get_day_of_week($w)
       <div class="h-full">
         <img src="../img/header-logo.png" alt="" class="h-full">
       </div>
-      <form action="../controllers/logoutPostController.php" method="POST">
-        <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
-      </form>
-      <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+      <div class="flex">
+        <form action="../controllers/logoutPostController.php" method="POST">
+          <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
+        </form>
+        <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+      </div>
     </div>
   </header>
   <main class="bg-gray-100">

--- a/src/admin/userRegister.php
+++ b/src/admin/userRegister.php
@@ -1,6 +1,6 @@
 <?php
 require_once(dirname(__FILE__) . "/../dbconnect.php");
-require_once(dirname(__FILE__) . "/../controllers/loginGetController.php");
+require_once(dirname(__FILE__) . "/../controllers/adminLoginGetController.php");
 session_start();
 
 

--- a/src/admin/userRegister.php
+++ b/src/admin/userRegister.php
@@ -34,6 +34,7 @@ function get_day_of_week($w)
       <form action="../controllers/logoutPostController.php" method="POST">
         <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
       </form>
+      <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
     </div>
   </header>
   <main class="bg-gray-100">
@@ -42,9 +43,8 @@ function get_day_of_week($w)
         <h2 class="text-sm font-bold mb-3">メニュー</h2>
         <div class="flex">
           <a href="./admin.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベントリスト</a>
-          <a href="" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー登録</a>
+          <a href="" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">ユーザー登録</a>
           <a href="./eventRegister.php" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">イベント追加</a>
-          <a href="/" class="px-3 py-2 text-xs font-bold mr-2 rounded-md shadow-md bg-white">ユーザー画面へ</a>
         </div>
       </div>
     <div class="w-full mx-auto py-10 px-5">

--- a/src/admin/userRegister.php
+++ b/src/admin/userRegister.php
@@ -31,10 +31,12 @@ function get_day_of_week($w)
       <div class="h-full">
         <img src="../img/header-logo.png" alt="" class="h-full">
       </div>
-      <form action="../controllers/logoutPostController.php" method="POST">
-        <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
-      </form>
-      <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+      <div class="flex">
+        <form action="../controllers/logoutPostController.php" method="POST">
+          <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
+        </form>
+        <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+      </div>
     </div>
   </header>
   <main class="bg-gray-100">

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -22,7 +22,7 @@ if (isset($_GET['event_id'])) {
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
 
-    $eventMessage = date("Y年m月d日", $start_date) . '（' . get_day_of_week(date("w", $start_date)) . '） ' . date("H:i", $start_date) . '~' . date("H:i", $end_date) . 'に' . $event['name'] . 'を開催します。<br>ぜひ参加してください。';
+    $eventMessage = nl2br(htmlspecialchars($event['detail'],ENT_QUOTES,'UTF-8'));
 
     $array = [
       'id' => $event['id'],

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -21,9 +21,7 @@ if (isset($_GET['event_id'])) {
     $login_user_attendance=$login_user_attendance_stmt->fetch()['attendance_status'];
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
-
     $eventMessage = nl2br(htmlspecialchars($event['detail'],ENT_QUOTES,'UTF-8'));
-
     $array = [
       'id' => $event['id'],
       'name' => $event['name'],

--- a/src/controllers/adminLoginGetController.php
+++ b/src/controllers/adminLoginGetController.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+// print_r('<pre>');
+// var_dump($_SESSION);
+// print_r('</pre>');
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    //ログインしてるか☑
+    if (!isset($_SESSION['login_bool'])||$_SESSION['login_bool']===0) {
+        header("Location: ../auth/login/index.php");
+    }
+    //管理者としてログインしてるか☑
+    if($_SESSION['login_user']['is_admin']!=1){
+        header("Location: ../auth/login/index.php");
+    }
+}

--- a/src/controllers/eventRegisterController.php
+++ b/src/controllers/eventRegisterController.php
@@ -10,12 +10,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $end_at = $_POST['end_at'];
 
     $regi_stmt = $db->prepare("INSERT INTO events (name, detail, start_at, end_at) VALUES (:name, :detail, :start_at, :end_at);");
-    $regi_stmt->bindValue(':name',$name);
-    $regi_stmt->bindValue(':detail',$detail);
-    $regi_stmt->bindValue(':start_at',$start_at);
-    $regi_stmt->bindValue(':end_at',$end_at);
+    $regi_stmt->bindValue(':name', $name);
+    $regi_stmt->bindValue(':detail', $detail);
+    $regi_stmt->bindValue(':start_at', $start_at);
+    $regi_stmt->bindValue(':end_at', $end_at);
     $regi_stmt->execute();
-
+    //登録したイベントのidを取得
+    $last_insert_event_id_stmt = $db->query("select id from events order by id desc limit 1;");
+    $last_insert_event_id_stmt->execute();
+    $last_insert_event_id = $last_insert_event_id_stmt->fetch()['id'];
+    $all_user_ids_stmt = $db->query("select id from users;");
+    $all_user_ids_stmt->execute();
+    $all_user_ids = $all_user_ids_stmt->fetchAll();
+    //全てのユーザー分登録したイベントに未回答で登録する
+    foreach ($all_user_ids as $user_id) {
+        $create_event_user_attendance_stmt = $db->prepare("insert into event_user_attendance (event_id,user_id) values (:event_id,:user_id);");
+        $create_event_user_attendance_stmt->bindValue(':event_id',$last_insert_event_id);
+        $create_event_user_attendance_stmt->bindValue(':user_id',$user_id['id']);
+        $create_event_user_attendance_stmt->execute();
+    }
     header("Location:  /../admin/admin.php");
     exit;
 }
+//管理画面のボタンの色の変化もやるべき。遷移してるから簡単

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,6 @@
 'use strict'
 const openModalClassList = document.querySelectorAll('.modal-open')
+const openAdminModalClassList=document.querySelectorAll('.admin-modal-open')
 const closeModalClassList = document.querySelectorAll('.modal-close')
 const overlay = document.querySelector('.modal-overlay')
 const body = document.querySelector('body')
@@ -13,7 +14,13 @@ for (let i = 0; i < openModalClassList.length; i++) {
     openModal(eventId)
   }, false)
 }
-
+for(let i=0;i<openAdminModalClassList.length;i++){
+  openAdminModalClassList[i].addEventListener('click',(e)=>{
+    e.preventDefault()
+    let eventId=parseInt(e.currentTarget.id.replace('event_',''))
+    openAdminModal(eventId)
+  })
+}
 for (var i = 0; i < closeModalClassList.length; i++) {
   closeModalClassList[i].addEventListener('click', closeModal)
 }
@@ -68,6 +75,31 @@ async function openModal(eventId) {
         `
         break;
     }
+    modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+  } catch (error) {
+    console.log(error)
+  }
+  toggleModal()
+}
+async function openAdminModal(eventId) {
+  try {
+    const url = '/api/getModalInfo.php?event_id=' + eventId
+    const res = await fetch(url)
+    const event = await res.json()
+    let modalHTML = `
+      <h2 class="text-md font-bold mb-3">${event.name}</h2>
+      <p class="text-sm">${event.date}（${event.day_of_week}）</p>
+      <p class="text-sm">${event.start_at} ~ ${event.end_at}</p>
+
+      <hr class="my-4">
+
+      <p class="text-md">
+        ${event.message}
+      </p>
+      <hr class="my-4">
+
+      <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+    `;
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
   } catch (error) {
     console.log(error)


### PR DESCRIPTION
## 関連イシュー
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/22
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/21
(管理者のみが管理画面にアクセスすることができるという機能が不十分だったためこちらで対応しました)

## 検証したこと
・一般ユーザーとしてログインし管理画面への導線がないことを確認
・管理ユーザーとしてログインし管理画面への導線があることを確認
・一般ユーザーとしてログインし、管理画面のURLを入力してアクセスするとログインページに飛ばされることを確認
・管理画面からイベント名、開催日時、イベント内容を入力して、イベント登録できる
・イベント登録すると全ユーザーの出欠が未回答でevent_user_attendanceテーブルに登録される
・イベントモーダルをユーザー画面と管理画面で開くとイベント内容が改行ありで表示できている
## エビデンス
・ユーザー一覧
![image](https://user-images.githubusercontent.com/86890087/189060615-a640b6c3-260a-48e3-9367-7896c88ba11e.png)
・一般ユーザーとしてログインし管理画面への導線がないことを確認
![image](https://user-images.githubusercontent.com/86890087/189059198-927a1ec9-91d3-4aec-a997-5f253b3c3750.png)
・管理ユーザーとしてログインし管理画面への導線があることを確認
![image](https://user-images.githubusercontent.com/86890087/189059340-5d2543d2-6887-403d-8450-439a098a826d.png)
・一般ユーザーとしてログインし、管理画面のURLを入力してアクセスするとログインページに飛ばされることを確認
https://user-images.githubusercontent.com/86890087/189060321-c1a2edb4-b5b3-4ec7-a8b3-6e8d9487a23c.mp4
・管理画面からイベント名、開催日時、イベント内容を入力して、イベント登録できる
![image](https://user-images.githubusercontent.com/86890087/189060792-64ba6f50-3b7b-4435-bbed-419e61a733e6.png)
![image](https://user-images.githubusercontent.com/86890087/189060963-ae183f6a-236e-42c4-96ef-972e799b04cc.png)
・イベント登録すると全ユーザーの出欠が未回答でevent_user_attendanceテーブルに登録される
![image](https://user-images.githubusercontent.com/86890087/189061201-b6141a01-5d7c-4574-90cd-b75db641c5fd.png)
・イベントモーダルをユーザー画面と管理画面で開くとイベント内容が改行ありで表示できている
ユーザー画面
![image](https://user-images.githubusercontent.com/86890087/189061555-30ca0ffb-ab93-4245-8f48-d3be37f6e3de.png)

管理画面
![image](https://user-images.githubusercontent.com/86890087/189061461-8fb745c9-f6ce-4add-9e87-b1880b3c8eaa.png)

