### PR TITLE
イベント参加管理 Issue5 イベント詳細画面のイベント参加人数をクリックすると、参加者が一覧表示される

### DIFF
--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -3,7 +3,7 @@ require_once(dirname(__FILE__) . "/../dbconnect.php");
 require_once(dirname(__FILE__) . "/../controllers/adminLoginGetController.php");
 session_start();
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) GROUP BY events.id ORDER BY events.start_at ASC');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) and event_user_attendance.attendance_status=1 GROUP BY events.id ORDER BY events.start_at ASC');
 $events = $stmt->fetchAll();
 
 function get_day_of_week($w)

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -99,6 +99,7 @@ function get_day_of_week($w)
   </div>
 
   <script src="/js/main.js"></script>
+  <script id="toggle_script"></script>
 </body>
 
 </html>

--- a/src/admin/admin.php
+++ b/src/admin/admin.php
@@ -3,7 +3,7 @@ require_once(dirname(__FILE__) . "/../dbconnect.php");
 require_once(dirname(__FILE__) . "/../controllers/adminLoginGetController.php");
 session_start();
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) GROUP BY events.id ORDER BY events.start_at ASC');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_user_attendance.id) AS total_participants FROM events LEFT JOIN event_user_attendance ON events.id = event_user_attendance.event_id WHERE events.start_at >= DATE(now()) and event_user_attendance.attendance_status=1 GROUP BY events.id ORDER BY events.start_at ASC');
 $events = $stmt->fetchAll();
 
 function get_day_of_week($w)
@@ -34,7 +34,7 @@ function get_day_of_week($w)
         <form action="../controllers/logoutPostController.php" method="POST">
           <input value="ログアウト" type="submit" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200 text-xs">
         </form>
-        <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+        <a href="/" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面</a>
       </div>
     </div>
   </header>
@@ -99,6 +99,7 @@ function get_day_of_week($w)
   </div>
 
   <script src="/js/main.js"></script>
+  <script id="toggle_script"></script>
 </body>
 
 </html>

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -7,23 +7,34 @@ if (isset($_GET['event_id'])) {
   $event_id = htmlspecialchars($_GET['event_id']);
   try {
     $stmt = $db->prepare('select id,name,start_at,end_at,detail from events where id= :id;');
-    $stmt->bindValue(':id',$event_id);
+    $stmt->bindValue(':id', $event_id);
     $stmt->execute();
     $event = $stmt->fetch();
-    $attendance_stmt=$db->prepare('select count(*) from event_user_attendance where event_id= :event_id and attendance_status=1;');
-    $attendance_stmt->bindValue(':event_id',$event_id);
+    $attendance_count_stmt = $db->prepare('select count(*) from event_user_attendance where event_id= :event_id and attendance_status=1;');
+    $attendance_count_stmt->bindValue(':event_id', $event_id);
+    $attendance_count_stmt->execute();
+    $total_participants = $attendance_count_stmt->fetch()['count(*)'];
+    $user_names_stmt = $db->query('select id,name from users;');
+    $user_names = $user_names_stmt->fetchAll(PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE);
+    //出席一覧を取得
+    $attendance_stmt = $db->prepare('select user_id from event_user_attendance where attendance_status=1 and event_id= :event_id;');
+    $attendance_stmt->bindValue(':event_id', $event_id);
     $attendance_stmt->execute();
-    $total_participants=$attendance_stmt->fetch()['count(*)'];
+    $attendances = $attendance_stmt->fetchAll();
+    //各ユーザーの出席にユーザー名の情報を追加する
+    foreach ($attendances as &$attendance) {
+      $attendance = $attendance + array('user_name' => $user_names[$attendance['user_id']]['name']);
+    }
     $login_user_attendance_stmt = $db->prepare('select attendance_status from event_user_attendance where user_id= :user_id and event_id= :event_id;');
-    $login_user_attendance_stmt->bindValue(':user_id',$_SESSION['login_user']['id']);
-    $login_user_attendance_stmt->bindValue(':event_id',$event_id);
+    $login_user_attendance_stmt->bindValue(':user_id', $_SESSION['login_user']['id']);
+    $login_user_attendance_stmt->bindValue(':event_id', $event_id);
     $login_user_attendance_stmt->execute();
-    $login_user_attendance=$login_user_attendance_stmt->fetch()['attendance_status'];
+    $login_user_attendance = $login_user_attendance_stmt->fetch()['attendance_status'];
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
-    $event_message = nl2br(htmlspecialchars($event['detail'],ENT_QUOTES,'UTF-8'));
+    $event_message = nl2br(htmlspecialchars($event['detail'], ENT_QUOTES, 'UTF-8'));
     $array = [
-      'current_date'=>date("Y-m-d"),
+      'current_date' => date("Y-m-d"),
       'id' => $event['id'],
       'name' => $event['name'],
       'date' => date("Y年m月d日", $start_date),
@@ -34,15 +45,18 @@ if (isset($_GET['event_id'])) {
       'message' => $event_message,
       'status' => $login_user_attendance,
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
+      'participants'=>json_encode($attendances)
     ];
     echo json_encode($array, JSON_UNESCAPED_UNICODE);
-  } catch(PDOException $e) {
+  } catch (PDOException $e) {
     echo $e->getMessage();
     exit();
   }
 }
 
-function get_day_of_week ($w) {
+function get_day_of_week($w)
+{
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+?>

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -7,23 +7,34 @@ if (isset($_GET['event_id'])) {
   $event_id = htmlspecialchars($_GET['event_id']);
   try {
     $stmt = $db->prepare('select id,name,start_at,end_at,detail from events where id= :id;');
-    $stmt->bindValue(':id',$event_id);
+    $stmt->bindValue(':id', $event_id);
     $stmt->execute();
     $event = $stmt->fetch();
-    $attendance_stmt=$db->prepare('select count(*) from event_user_attendance where event_id= :event_id and attendance_status=1;');
-    $attendance_stmt->bindValue(':event_id',$event_id);
+    $attendance_count_stmt = $db->prepare('select count(*) from event_user_attendance where event_id= :event_id and attendance_status=1;');
+    $attendance_count_stmt->bindValue(':event_id', $event_id);
+    $attendance_count_stmt->execute();
+    $total_participants = $attendance_count_stmt->fetch()['count(*)'];
+    $user_names_stmt = $db->query('select id,name from users;');
+    $user_names = $user_names_stmt->fetchAll(PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE);
+    //出席一覧を取得
+    $attendance_stmt = $db->prepare('select user_id from event_user_attendance where attendance_status=1 and event_id= :event_id;');
+    $attendance_stmt->bindValue(':event_id', $event_id);
     $attendance_stmt->execute();
-    $total_participants=$attendance_stmt->fetch()['count(*)'];
+    $attendances = $attendance_stmt->fetchAll();
+    //各ユーザーの出席にユーザー名の情報を追加する
+    foreach ($attendances as &$attendance) {
+      $attendance = $attendance + array('user_name' => $user_names[$attendance['user_id']]['name']);
+    }
     $login_user_attendance_stmt = $db->prepare('select attendance_status from event_user_attendance where user_id= :user_id and event_id= :event_id;');
-    $login_user_attendance_stmt->bindValue(':user_id',$_SESSION['login_user']['id']);
-    $login_user_attendance_stmt->bindValue(':event_id',$event_id);
+    $login_user_attendance_stmt->bindValue(':user_id', $_SESSION['login_user']['id']);
+    $login_user_attendance_stmt->bindValue(':event_id', $event_id);
     $login_user_attendance_stmt->execute();
-    $login_user_attendance=$login_user_attendance_stmt->fetch()['attendance_status'];
+    $login_user_attendance = $login_user_attendance_stmt->fetch()['attendance_status'];
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
-    $event_message = nl2br(htmlspecialchars($event['detail'],ENT_QUOTES,'UTF-8'));
+    $event_message = nl2br(htmlspecialchars($event['detail'], ENT_QUOTES, 'UTF-8'));
     $array = [
-      'current_date'=>date("Y-m-d"),
+      'current_date' => date("Y-m-d"),
       'id' => $event['id'],
       'name' => $event['name'],
       'date' => date("Y年m月d日", $start_date),
@@ -34,15 +45,17 @@ if (isset($_GET['event_id'])) {
       'message' => $event_message,
       'status' => $login_user_attendance,
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
+      'participants'=>json_encode($attendances)
     ];
     echo json_encode($array, JSON_UNESCAPED_UNICODE);
-  } catch(PDOException $e) {
+  } catch (PDOException $e) {
     echo $e->getMessage();
     exit();
   }
 }
 
-function get_day_of_week ($w) {
+function get_day_of_week($w)
+{
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }

--- a/src/controllers/eventRegisterController.php
+++ b/src/controllers/eventRegisterController.php
@@ -35,4 +35,3 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     header("Location:  /../admin/admin.php");
     exit;
 }
-//管理画面のボタンの色の変化もやるべき。遷移してるから簡単

--- a/src/controllers/eventsGetController.php
+++ b/src/controllers/eventsGetController.php
@@ -13,14 +13,25 @@ function group_by($key, array $ary): array
 
     return $result;
 }
+$user_names_stmt = $db->query('select id,name from users;');
+$user_names = $user_names_stmt->fetchAll(PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE);
+
 //イベント一覧を取得,idをキーとすることでeager loadの再現をしやすくしている
 $events_stmt = $db->query('select id,name,start_at,end_at,detail from events order by start_at asc;');
 $events = $events_stmt->fetchAll(PDO::FETCH_ASSOC | PDO::FETCH_UNIQUE);
+
 //出席一覧を取得
 $attendance_stmt = $db->query('select event_id,user_id,attendance_status from event_user_attendance order by attendance_status;');
 $attendances = $attendance_stmt->fetchAll();
+
+//各ユーザーの出席にユーザー名の情報を追加する
+foreach ($attendances as &$attendance) {
+    $attendance = $attendance + array('user_name' => $user_names[$attendance['user_id']]['name']);
+}
+
 //出席一覧をイベントによってgroupbyする。laravelのeager loadを再現してる
 $event_user_attendances_grouped_by_event_id = group_by('event_id', $attendances);
+
 //ログインユーザーのイベントのattendance_statusを取得
 $login_user_attendance_stmt = $db->prepare('select event_id,attendance_status from event_user_attendance where user_id= :user_id order by event_id;');
 $login_user_attendance_stmt->bindValue(':user_id', $_SESSION['login_user']['id']);
@@ -39,9 +50,9 @@ $events_filtered_by_login_user_attendance_status = [];
 if (!isset($_GET['attendance_status'])) {
     $events_filtered_by_login_user_attendance_status = $events;
 } else {
-    foreach ($events as $event_id=>$event) {
+    foreach ($events as $event_id => $event) {
         if ($_GET['attendance_status'] === $event['login_user_attendance_status']) {
-            $events_filtered_by_login_user_attendance_status=$events_filtered_by_login_user_attendance_status+array($event_id=>$event);
+            $events_filtered_by_login_user_attendance_status = $events_filtered_by_login_user_attendance_status + array($event_id => $event);
         }
     }
 }

--- a/src/index.php
+++ b/src/index.php
@@ -35,7 +35,7 @@ function get_day_of_week($w)
         <?php
         // echo $_SESSION['login_user']['is_admin'];
         if ($_SESSION['login_user']['is_admin']) {
-          echo '<a href="./admin/admin.php" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">管理者画面へ</a>';
+          echo '<a href="./admin/admin.php" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">管理者画面</a>';
         }
         ?>
       </div>
@@ -84,41 +84,52 @@ function get_day_of_week($w)
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event_<?php echo $event_id; ?>">
-            <div>
-              <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
-              <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
-              <p class="text-xs text-gray-600">
-                <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
-              </p>
-            </div>
-            <div class="flex flex-col justify-between text-right">
+          <div class="bg-white mb-3 p-4 shadow-md rounded-md">
+            <div class="modal-open flex justify-between cursor-pointer" id="event_<?php echo $event_id; ?>">
               <div>
-                <?php if ($event['login_user_attendance_status'] == 0) : ?>
-                  <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $start_date)); ?></p>
-                <?php elseif ($event['login_user_attendance_status'] == 2) : ?>
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                <?php elseif ($event['login_user_attendance_status'] == 1) : ?>
-                  <p class="text-sm font-bold text-green-400">参加</p>
-                <?php endif; ?>
+                <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+                <p class="text-xs text-gray-600">
+                  <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+                </p>
               </div>
-              <p class="text-sm"><span class="text-xl">
-                  <?php
-                  if (isset($event['attendance_status'][1])) {
-                    echo count($event['attendance_status'][1]);
-                  } else {
-                    echo 0;
-                  }
-                  ?></span>人参加 ></p>
+              <div class="flex flex-col justify-between text-right">
+                <div>
+                  <?php if ($event['login_user_attendance_status'] == 0) : ?>
+                    <p class="text-sm font-bold text-yellow-400">未回答</p>
+                    <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $start_date)); ?></p>
+                  <?php elseif ($event['login_user_attendance_status'] == 2) : ?>
+                    <p class="text-sm font-bold text-gray-300">不参加</p>
+                  <?php elseif ($event['login_user_attendance_status'] == 1) : ?>
+                    <p class="text-sm font-bold text-green-400">参加</p>
+                  <?php endif; ?>
+                </div>
+              </div>
+            </div>
+            <p id="show_participants_<?php echo $event_id; ?>" class="text-sm show_participants"><span class="text-xl">
+                <?php
+                if (isset($event['attendance_status'][1])) {
+                  echo count($event['attendance_status'][1]);
+                } else {
+                  echo 0;
+                }
+                ?></span>人参加 ></p>
+            <div class="hidden" id="participants_<?php echo $event_id; ?>">
+              <p>参加者一覧</p>
+              <div>
+                <?php
+                foreach ($event['attendance_status'][1] as $participant) {
+                  echo '・' . $participant['user_name'] . '<br>';
+                }
+                ?>
+              </div>
             </div>
           </div>
         <?php endforeach; ?>
       </div>
-    </div>
-    <?php
-    include_once(dirname(__FILE__) . "/pagination/footer.php");
-    ?>
+      <?php
+      include_once(dirname(__FILE__) . "/pagination/footer.php");
+      ?>
   </main>
 
   <div class="modal opacity-0 pointer-events-none fixed w-full h-full top-0 left-0 flex items-center justify-center">
@@ -140,6 +151,7 @@ function get_day_of_week($w)
   </div>
 
   <script src="/js/main.js"></script>
+  <script id="toggle_script"></script>
 </body>
 
 </html>

--- a/src/index.php
+++ b/src/index.php
@@ -84,33 +84,46 @@ function get_day_of_week($w)
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           ?>
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event_<?php echo $event_id; ?>">
-            <div>
-              <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
-              <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
-              <p class="text-xs text-gray-600">
-                <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
-              </p>
-            </div>
-            <div class="flex flex-col justify-between text-right">
+          <div class="bg-white mb-3 p-4 shadow-md rounded-md">
+            <div class="modal-open flex justify-between cursor-pointer" id="event_<?php echo $event_id; ?>">
               <div>
-                <?php if ($event['login_user_attendance_status'] == 0) : ?>
-                  <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $start_date)); ?></p>
-                <?php elseif ($event['login_user_attendance_status'] == 2) : ?>
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                <?php elseif ($event['login_user_attendance_status'] == 1) : ?>
-                  <p class="text-sm font-bold text-green-400">参加</p>
-                <?php endif; ?>
+                <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+                <p class="text-xs text-gray-600">
+                  <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+                </p>
               </div>
-              <p class="text-sm"><span class="text-xl">
-                  <?php
-                  if (isset($event['attendance_status'][1])) {
-                    echo count($event['attendance_status'][1]);
-                  } else {
-                    echo 0;
-                  }
-                  ?></span>人参加 ></p>
+              <div class="flex flex-col justify-between text-right">
+                <div>
+                  <?php if ($event['login_user_attendance_status'] == 0) : ?>
+                    <p class="text-sm font-bold text-yellow-400">未回答</p>
+                    <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $start_date)); ?></p>
+                  <?php elseif ($event['login_user_attendance_status'] == 2) : ?>
+                    <p class="text-sm font-bold text-gray-300">不参加</p>
+                  <?php elseif ($event['login_user_attendance_status'] == 1) : ?>
+                    <p class="text-sm font-bold text-green-400">参加</p>
+                  <?php endif; ?>
+                </div>
+              </div>
+            </div>
+                <p class="text-sm show_participants"><span class="text-xl">
+                    <?php
+                    if (isset($event['attendance_status'][1])) {
+                      echo count($event['attendance_status'][1]);
+                    } else {
+                      echo 0;
+                    }
+                    ?></span>人参加 ></p>
+            <div>
+              <!-- ユーザー一覧 -->
+              <p>参加ユーザー一覧</p>
+              <div>
+                <?php
+                foreach ($event['attendance_status'][1] as $participant) {
+                  echo '・'.$participant['user_name'] . '<br>';
+                }
+                ?>
+              </div>
             </div>
           </div>
         <?php endforeach; ?>

--- a/src/index.php
+++ b/src/index.php
@@ -106,7 +106,7 @@ function get_day_of_week($w)
                 </div>
               </div>
             </div>
-                <p class="text-sm show_participants"><span class="text-xl">
+                <p id="show_participants_<?php echo $event_id;?>" class="text-sm show_participants"><span class="text-xl">
                     <?php
                     if (isset($event['attendance_status'][1])) {
                       echo count($event['attendance_status'][1]);
@@ -114,9 +114,8 @@ function get_day_of_week($w)
                       echo 0;
                     }
                     ?></span>人参加 ></p>
-            <div>
-              <!-- ユーザー一覧 -->
-              <p>参加ユーザー一覧</p>
+            <div class="hidden" id="participants_<?php echo $event_id;?>">
+              <p>参加者一覧</p>
               <div>
                 <?php
                 foreach ($event['attendance_status'][1] as $participant) {

--- a/src/index.php
+++ b/src/index.php
@@ -33,9 +33,8 @@ function get_day_of_week($w)
           <input value="ログアウト" type="submit" class="mr-2 text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">
         </form>
         <?php
-        // echo $_SESSION['login_user']['is_admin'];
         if ($_SESSION['login_user']['is_admin']) {
-          echo '<a href="./admin/admin.php" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">管理者画面へ</a>';
+          echo '<a href="./admin/admin.php" class="text-xs text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">管理者画面</a>';
         }
         ?>
       </div>
@@ -149,6 +148,7 @@ function get_day_of_week($w)
   </div>
 
   <script src="/js/main.js"></script>
+  <script id="toggle_script"></script>
 </body>
 
 </html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -2,6 +2,7 @@
 const openModalClassList = document.querySelectorAll('.modal-open')
 const openAdminModalClassList=document.querySelectorAll('.admin-modal-open')
 const closeModalClassList = document.querySelectorAll('.modal-close')
+const showParticipantsClassList=document.querySelectorAll('.show_participants')
 const overlay = document.querySelector('.modal-overlay')
 const body = document.querySelector('body')
 const modal = document.querySelector('.modal')
@@ -27,6 +28,13 @@ for (var i = 0; i < closeModalClassList.length; i++) {
 
 overlay.addEventListener('click', closeModal)
 
+for(let i=0;i<showParticipantsClassList.length;i++){
+  showParticipantsClassList[i].addEventListener('click',(e)=>{
+    e.preventDefault()
+    let eventId=parseInt(e.currentTarget.id.replace('show_participants_',''))
+    document.getElementById(`participants_${eventId}`).classList.toggle('hidden')
+  })
+}
 
 async function openModal(eventId) {
   try {
@@ -47,7 +55,7 @@ async function openModal(eventId) {
       <hr class="my-4">
 
       <p id="show_modal_participants" class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
-      <div>
+      <div id="modal_participants">
     `;
     Object.keys(obj).forEach(function(key){
       modalHTML+=obj[key]['user_name']+'<br>'
@@ -120,7 +128,7 @@ async function openAdminModal(eventId) {
       <div id="admin_participants">
     `;
     Object.keys(obj).forEach(function(key){
-      modalHTML+=obj[key]['user_name']+'<br>'
+      modalHTML+='・'+obj[key]['user_name']+'<br>'
     })
     modalHTML+='</div>'
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -33,6 +33,7 @@ async function openModal(eventId) {
     const url = '/api/getModalInfo.php?event_id=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    const obj=JSON.parse(event.participants)
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -45,8 +46,13 @@ async function openModal(eventId) {
       </p>
       <hr class="my-4">
 
-      <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+      <p id="show_modal_participants" class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+      <div>
     `;
+    Object.keys(obj).forEach(function(key){
+      modalHTML+=obj[key]['user_name']+'<br>'
+    })
+    modalHTML+='</div>'
     switch (event.status) {
       case '0':
         modalHTML += `
@@ -75,6 +81,7 @@ async function openModal(eventId) {
         `
         break;
     }
+    
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
   } catch (error) {
     console.log(error)
@@ -86,6 +93,7 @@ async function openAdminModal(eventId) {
     const url = '/api/getModalInfo.php?event_id=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    const obj=JSON.parse(event.participants)
     let modalHTML = `
     <input class="border-solid border-black border" hidden name="event_id" value="${eventId}">
     <div>
@@ -108,8 +116,13 @@ async function openAdminModal(eventId) {
     
 
 
-      <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+      <p id="show_admin_participants" class="text-sm"><span class="text-xl show_participants">${event.total_participants}</span>人参加 ></p>
+      <div id="admin_participants">
     `;
+    Object.keys(obj).forEach(function(key){
+      modalHTML+=obj[key]['user_name']+'<br>'
+    })
+    modalHTML+='</div>'
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
   } catch (error) {
     console.log(error)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -36,6 +36,8 @@ for(let i=0;i<showParticipantsClassList.length;i++){
   })
 }
 
+
+
 async function openModal(eventId) {
   try {
     const url = '/api/getModalInfo.php?event_id=' + eventId
@@ -55,7 +57,7 @@ async function openModal(eventId) {
       <hr class="my-4">
 
       <p id="show_modal_participants" class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
-      <div id="modal_participants">
+      <div class="hidden" id="modal_participants">
     `;
     Object.keys(obj).forEach(function(key){
       modalHTML+=obj[key]['user_name']+'<br>'
@@ -91,11 +93,17 @@ async function openModal(eventId) {
     }
     
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+    document.getElementById('toggle_script').innerHTML=`document.getElementById('show_modal_participants').addEventListener('click',function(){
+      document.getElementById('modal_participants').classList.toggle('hidden')
+    })`
   } catch (error) {
     console.log(error)
   }
   toggleModal()
 }
+
+
+
 async function openAdminModal(eventId) {
   try {
     const url = '/api/getModalInfo.php?event_id=' + eventId
@@ -125,23 +133,26 @@ async function openAdminModal(eventId) {
 
 
       <p id="show_admin_participants" class="text-sm"><span class="text-xl show_participants">${event.total_participants}</span>人参加 ></p>
-      <div id="admin_participants">
+      <div class="hidden" id="admin_participants">
     `;
     Object.keys(obj).forEach(function(key){
       modalHTML+='・'+obj[key]['user_name']+'<br>'
     })
     modalHTML+='</div>'
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+    document.getElementById('toggle_script').innerHTML=`document.getElementById('show_admin_participants').addEventListener('click',function(){
+      document.getElementById('admin_participants').classList.toggle('hidden');
+    })`
   } catch (error) {
     console.log(error)
   }
   toggleModal()
 }
-// 過去の日程選べないようにする（過去表示されないから間違えると戻れない）
 
 function closeModal() {
   modalInnerHTML.innerHTML = ''
   toggleModal()
+  location.reload();
 }
 
 function toggleModal() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,6 +3,7 @@ const openModalClassList = document.querySelectorAll('.modal-open')
 const openAdminModalClassList=document.querySelectorAll('.admin-modal-open')
 const closeModalClassList = document.querySelectorAll('.modal-close')
 const overlay = document.querySelector('.modal-overlay')
+const showParticipantsClassList=document.querySelectorAll('.show_participants')
 const body = document.querySelector('body')
 const modal = document.querySelector('.modal')
 const modalInnerHTML = document.getElementById('modalInner')
@@ -27,12 +28,20 @@ for (var i = 0; i < closeModalClassList.length; i++) {
 
 overlay.addEventListener('click', closeModal)
 
+for(let i=0;i<showParticipantsClassList.length;i++){
+  showParticipantsClassList[i].addEventListener('click',(e)=>{
+    e.preventDefault()
+    let eventId=parseInt(e.currentTarget.id.replace('show_participants_',''))
+    document.getElementById(`participants_${eventId}`).classList.toggle('hidden')
+  })
+}
 
 async function openModal(eventId) {
   try {
     const url = '/api/getModalInfo.php?event_id=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    const obj=JSON.parse(event.participants)
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -45,8 +54,14 @@ async function openModal(eventId) {
       </p>
       <hr class="my-4">
 
-      <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+      <p id="show_modal_participants" class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+      <div class="hidden" id="modal_participants">
     `;
+    Object.keys(obj).forEach(function(key){
+      modalHTML+=obj[key]['user_name']+'<br>'
+    })
+    modalHTML+='</div>'
+    
     switch (event.status) {
       case '0':
         modalHTML += `
@@ -76,6 +91,9 @@ async function openModal(eventId) {
         break;
     }
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+    document.getElementById('toggle_script').innerHTML=`document.getElementById('show_modal_participants').addEventListener('click',function(){
+      document.getElementById('modal_participants').classList.toggle('hidden')
+    })`
   } catch (error) {
     console.log(error)
   }
@@ -86,6 +104,7 @@ async function openAdminModal(eventId) {
     const url = '/api/getModalInfo.php?event_id=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    const obj=JSON.parse(event.participants)
     let modalHTML = `
     <input class="border-solid border-black border" hidden name="event_id" value="${eventId}">
     <div>
@@ -108,9 +127,17 @@ async function openAdminModal(eventId) {
     
 
 
-      <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+    <p id="show_admin_participants" class="text-sm"><span class="text-xl show_participants">${event.total_participants}</span>人参加 ></p>
+    <div class="hidden" id="admin_participants">    
     `;
+    Object.keys(obj).forEach(function(key){
+      modalHTML+='・'+obj[key]['user_name']+'<br>'
+    })
+    modalHTML+='</div>'
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+    document.getElementById('toggle_script').innerHTML=`document.getElementById('show_admin_participants').addEventListener('click',function(){
+      document.getElementById('admin_participants').classList.toggle('hidden');
+    })`
   } catch (error) {
     console.log(error)
   }
@@ -121,6 +148,7 @@ async function openAdminModal(eventId) {
 function closeModal() {
   modalInnerHTML.innerHTML = ''
   toggleModal()
+  location.reload()
 }
 
 function toggleModal() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -58,7 +58,7 @@ async function openModal(eventId) {
       <div class="hidden" id="modal_participants">
     `;
     Object.keys(obj).forEach(function(key){
-      modalHTML+=obj[key]['user_name']+'<br>'
+      modalHTML+='・'+obj[key]['user_name']+'<br>'
     })
     modalHTML+='</div>'
     


### PR DESCRIPTION
## 関連イシュー
https://github.com/posse-ap/posse1-hackathon-202209-team2D/issues/16
## 検証したこと
トップページで○○人参加押す前と押した後の比較
イベント詳細画面で○○人参加押す前と押した後の比較
## エビデンス
トップページ
https://user-images.githubusercontent.com/86890087/189122544-351ed916-3f89-4916-bcd5-b0c482ba8a60.mp4
イベント詳細画面
https://user-images.githubusercontent.com/86890087/189122698-9b0b1b96-612f-4110-a46b-1842c6be301b.mp4

